### PR TITLE
feat!: use beasties build-time compiler and zero-dependency runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 ## Features
 
 - Zero-configuration required
-- Enables CSS Extraction
+- Stylesheets are compiled at build time, so no CSS parser or DOM is needed at runtime
 - Critical CSS automatically injected to page
-- Works with Nitro prerendering
+- Works with runtime SSR and Nitro prerendering
 
 ## Quick setup
 
@@ -41,6 +41,10 @@ Nuxt has a number of ways to optimize your CSS in production:
 2. 📦 You can enable [`purgecss`](https://github.com/Developmint/nuxt-purgecss) to remove unused CSS rules from your bundle.
 3. ✅ with `@nuxtjs/critters` you can now extract CSS files and load them separately, just inlining the CSS necessary to render the page.
 
+At build time the module compiles every CSS asset emitted by the client build into a compact plan with [`beasties/compiler`](https://github.com/danielroe/beasties), and embeds those plans in the server bundle. At request (or prerender) time a Nitro plugin runs the zero-dependency `beasties/runtime` processor over the rendered HTML, which scans the markup in a single pass and inlines only the rules that can match.
+
+Because inlined component styles never become external CSS assets (and so can never be pruned), the module disables `features.inlineStyles`.
+
 ## Options
 
 You can override the `@nuxtjs/critters` defaults like this:
@@ -51,7 +55,6 @@ import { defineNuxtConfig } from 'nuxt'
 export default defineNuxtConfig({
   modules: ['@nuxtjs/critters'],
   critters: {
-    // Options passed directly to beasties: https://github.com/danielroe/beasties#beasties-
     config: {
       // Default: 'media'
       preload: 'swap',
@@ -59,6 +62,29 @@ export default defineNuxtConfig({
   },
 })
 ```
+
+Supported `config` keys are the compiler's `allowRules` and `exact`, plus the runtime processor options: `preload`, `noscriptFallback`, `keyframes`, `fonts`, `inlineFonts`, `preloadFonts`, `cache`, `inlineThreshold` and `minimumExternalSize`.
+
+### Differences from classic beasties
+
+Some options of the classic (per-request, DOM-based) beasties API have no equivalent in the compiler + runtime pipeline:
+
+- `pruneSource` — the runtime does not rewrite the external stylesheet, so rules that were inlined are still served by it.
+- `path`, `publicPath`, `external`, `remote`, `additionalStylesheets`, `mergeStylesheets` — stylesheets are taken from the client build's emitted assets rather than resolved from the filesystem or network.
+- `reduceInlineStyles`, `compress`, `safeParser`, `logLevel`, `logger`, `dedupeWarnings` — parsing, minification and diagnostics all happen at build time, and compiler warnings are reported through the Nuxt logger.
+
+Two behaviours also differ:
+
+- `minimumExternalSize` is measured against the rules that were *not* inlined, i.e. what the external stylesheet would still need to provide, rather than against a rewritten external stylesheet.
+- `cache` defaults to being enabled only when the total compiled CSS is large enough that fingerprinting a document is cheaper than re-evaluating the plans. Set `cache: true` or `cache: false` to decide explicitly.
+
+## CSP nonces
+
+The module reads the per-request nonce from `event.context.security.nonce` and applies it to the `<style>` and `<script>` elements it injects. With [`nuxt-security`](https://nuxt-security.com) and its `nonce` support enabled, this needs no configuration.
+
+It has to happen here rather than in the module that generates the nonce: `nuxt-security` stamps nonces onto rendered tags in Nitro's `render:html` hook, which runs *before* the `render:response` hook where critical CSS is inlined, so anything injected there is invisible to that pass. When the event carries no nonce — during prerendering, for instance — nothing is added.
+
+beasties itself also accepts a `nonce` option, but it is not exposed here: a value fixed at build time is constant for the lifetime of the server, which defeats the point of a nonce.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^4.0.0",
-    "beasties": "^0.4.0",
-    "pathe": "^2.0.0",
+    "beasties": "^0.5.2",
     "ufo": "^1.5.4"
   },
   "devDependencies": {
@@ -58,6 +57,7 @@
     "eslint": "10.9.1",
     "lint-staged": "17.4.1",
     "nuxt": "4.5.2",
+    "pathe": "^2.0.0",
     "simple-git-hooks": "2.14.0",
     "vitest": "4.1.11"
   },

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,6 +1,8 @@
 <template>
   <div :class="toggle ? 'sample-class' : 'sample-unused-class'">
-    some text
+    <p class="sample-media-class sample-animated">
+      some text
+    </p>
     <button @click="toggle = !toggle">
       Toggle class
     </button>

--- a/playground/styles/global.css
+++ b/playground/styles/global.css
@@ -1,3 +1,27 @@
 body {
   background: darkgoldenrod;
 }
+
+.sample-animated {
+  animation: sample-fade 1s ease-in;
+}
+
+@keyframes sample-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes sample-unused-keyframes {
+  from { transform: none; }
+  to { transform: scale(2); }
+}
+
+@media (min-width: 100px) {
+  .sample-media-class {
+    color: white;
+  }
+
+  .sample-unused-media-class {
+    color: black;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,11 +16,8 @@ importers:
         specifier: ^4.0.0
         version: 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       beasties:
-        specifier: ^0.4.0
-        version: 0.4.3
-      pathe:
-        specifier: ^2.0.0
-        version: 2.0.3
+        specifier: ^0.5.2
+        version: 0.5.2
       ufo:
         specifier: ^1.5.4
         version: 1.6.4
@@ -52,6 +49,9 @@ importers:
       nuxt:
         specifier: 4.5.2
         version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(rolldown@1.2.4)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@5.9.3)(vite@8.2.1(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(yaml@2.9.0)
+      pathe:
+        specifier: ^2.0.0
+        version: 2.0.3
       simple-git-hooks:
         specifier: 2.14.0
         version: 2.14.0
@@ -1784,9 +1784,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  beasties@0.4.3:
-    resolution: {integrity: sha512-fIIeLOcbAB/K1kb1HBVJoiq1alHL4RCYBSo5e7HzrNkkgMggXR1Vqt/Z9JWnkfe/qdCo66Ux3QRwZioAIBdWRA==}
-    engines: {node: '>=18.0.0'}
+  beasties@0.5.2:
+    resolution: {integrity: sha512-S6IQRZ8h9lUaNr6TXbJHF3tJPwHBBmm2UqYKts5fDC1TfSN1DkWkLoi2XiRW8v04Kop9pdT4cZdQq0VY8KoNZg==}
+    engines: {node: '>=20.19.0'}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -1799,6 +1799,10 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  boolbase@2.0.0:
+    resolution: {integrity: sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==}
+    engines: {node: '>=20.19.0'}
 
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
@@ -1995,8 +1999,9 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
-  css-select@6.0.0:
-    resolution: {integrity: sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==}
+  css-select@7.0.0:
+    resolution: {integrity: sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==}
+    engines: {node: '>=20.19.0'}
 
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
@@ -2010,9 +2015,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
-  css-what@7.0.0:
-    resolution: {integrity: sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==}
-    engines: {node: '>= 6'}
+  css-what@8.0.0:
+    resolution: {integrity: sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==}
+    engines: {node: '>=20.19.0'}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -2145,15 +2150,31 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dot-prop@10.2.0:
     resolution: {integrity: sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==}
@@ -2195,6 +2216,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
@@ -2593,8 +2618,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  htmlparser2@10.1.0:
-    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -3136,6 +3162,10 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nth-check@3.0.1:
+    resolution: {integrity: sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==}
+    engines: {node: '>=20.19.0'}
 
   nuxt@4.5.2:
     resolution: {integrity: sha512-tR3fcqeHlHmmkLMpIg3V7Y+1ltr302lW8djMw/iy+myfo7QSSz+BVJDuQhg5j73b9oteSyBfOKTDYTgvMtj6TA==}
@@ -6552,13 +6582,13 @@ snapshots:
 
   baseline-browser-mapping@2.11.14: {}
 
-  beasties@0.4.3:
+  beasties@0.5.2:
     dependencies:
-      css-select: 6.0.0
-      css-what: 7.0.0
-      dom-serializer: 2.0.0
-      domhandler: 5.0.3
-      htmlparser2: 10.1.0
+      css-select: 7.0.0
+      css-what: 8.0.0
+      dom-serializer: 3.1.1
+      domhandler: 6.0.1
+      htmlparser2: 12.0.0
       picocolors: 1.1.1
       postcss: 8.5.26
       postcss-media-query-parser: 0.2.3
@@ -6573,6 +6603,8 @@ snapshots:
   birpc@4.1.0: {}
 
   boolbase@1.0.0: {}
+
+  boolbase@2.0.0: {}
 
   brace-expansion@2.1.4:
     dependencies:
@@ -6763,13 +6795,13 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
-  css-select@6.0.0:
+  css-select@7.0.0:
     dependencies:
-      boolbase: 1.0.0
-      css-what: 7.0.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      nth-check: 2.1.1
+      boolbase: 2.0.0
+      css-what: 8.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      nth-check: 3.0.1
 
   css-tree@2.2.1:
     dependencies:
@@ -6783,7 +6815,7 @@ snapshots:
 
   css-what@6.2.2: {}
 
-  css-what@7.0.0: {}
+  css-what@8.0.0: {}
 
   cssesc@3.0.0: {}
 
@@ -6923,17 +6955,35 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
 
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dot-prop@10.2.0:
     dependencies:
@@ -6960,6 +7010,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   error-stack-parser-es@1.0.5: {}
 
@@ -7443,12 +7495,12 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  htmlparser2@10.1.0:
+  htmlparser2@12.0.0:
     dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      entities: 7.0.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
 
   http-errors@2.0.1:
     dependencies:
@@ -8033,6 +8085,10 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nth-check@3.0.1:
+    dependencies:
+      boolbase: 2.0.0
 
   nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(rolldown@1.2.4)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@5.9.3)(vite@8.2.1(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,6 @@ allowBuilds:
   esbuild: false
   simple-git-hooks: true
   unrs-resolver: false
+
+minimumReleaseAgeExclude:
+  - beasties@0.5.0 || 0.5.2

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,14 +1,25 @@
-import { readFile, writeFile } from 'node:fs/promises'
-import { defineNuxtModule, isNuxtMajorVersion, useLogger } from '@nuxt/kit'
-import { resolve } from 'pathe'
-import { withoutLeadingSlash } from 'ufo'
-import Beasties from 'beasties'
-import type { Options } from 'beasties'
+import { addServerPlugin, createResolver, defineNuxtModule, useLogger } from '@nuxt/kit'
+import { compileSheet, encodePlan } from 'beasties/compiler'
+import type { CompileOptions } from 'beasties/compiler'
+import type { ProcessorOptions } from 'beasties/runtime'
+import { joinURL, withLeadingSlash, withoutLeadingSlash } from 'ufo'
+
+/** The nonce is read from the request, so it is not configurable */
+export interface CrittersConfig extends Omit<ProcessorOptions, 'nonce'>, Pick<CompileOptions, 'allowRules' | 'exact'> {}
 
 export interface ModuleOptions {
-  // Options passed directly to `beasties`
-  config?: Options
+  // Options passed to the `beasties` compiler and runtime
+  config?: CrittersConfig
 }
+
+/** Above this, embedding compiled plans in the server bundle is worth flagging */
+const PLAN_SIZE_WARNING = 512 * 1024
+
+/**
+ * Below this total CSS size, evaluating the compiled sheets per request costs
+ * less than fingerprinting the document to look up a cached result.
+ */
+const CACHE_CSS_SIZE_THRESHOLD = 30 * 1024
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
@@ -25,65 +36,68 @@ export default defineNuxtModule<ModuleOptions>({
     if (nuxt.options.dev) return
 
     const logger = useLogger('critters')
+    const resolver = createResolver(import.meta.url)
 
-    // Enable css extraction
-    // @ts-expect-error TODO: use @nuxt/bridge-schema
-    nuxt.options.build.extractCSS = true
+    // Inlined component styles are never emitted as CSS assets, so they cannot
+    // be pruned - and leaving them on ships the same rules twice
+    nuxt.options.features.inlineStyles = false
 
-    // Nitro handler (for prerendering only)
+    const stylesheets = new Map<string, string>()
 
-    const generatedFiles = new Set<string>()
-    nuxt.hook('nitro:init', (nitro) => {
-      nitro.hooks.hook('prerender:generate', (route) => {
-        if (!route.fileName?.endsWith('.html') || route.error) return
-        generatedFiles.add(withoutLeadingSlash(route.fileName))
+    nuxt.hook('vite:extendConfig', (config, { isClient }) => {
+      if (!isClient) return
+      config.plugins!.push({
+        name: 'critters:collect-stylesheets',
+        generateBundle(_outputOptions, bundle) {
+          for (const [fileName, asset] of Object.entries(bundle)) {
+            if (asset.type !== 'asset' || !fileName.endsWith('.css')) continue
+            stylesheets.set(fileName, asset.source.toString())
+          }
+        },
       })
     })
-    nuxt.hook('nitro:build:public-assets', async (nitro) => {
-      const beasties = new Beasties({
-        path: nitro.options.output.publicDir,
-        publicPath: nitro.options.baseURL,
-        ...options.config,
-      })
-      for (const file of generatedFiles) {
-        try {
-          const path = resolve(nitro.options.output.publicDir, file)
-          const contents = await readFile(path, 'utf-8')
-          const processed = await beasties.process(contents)
-          await writeFile(path, processed)
-        }
-        catch {
-          logger.log(`Could not inline CSS in \`${file}\`.`)
-        }
-      }
-    })
 
-    /* c8 ignore start */
-    if (!isNuxtMajorVersion(2)) {
-      const beasties = new Beasties({
-        path: resolve(nuxt.options.buildDir, 'dist/client'),
-        // @ts-expect-error TODO: use @nuxt/bridge-schema
-        publicPath: nuxt.options.build.publicPath,
-        ...options.config,
-      })
-
-      // Add transform step
-      // @ts-expect-error TODO: use @nuxt/bridge-schema
-      nuxt.hook('render:route', async (_url, result) => {
-        if (!result.html || result.error) return
-        try {
-          result.html = await beasties.process(result.html)
-        }
-        catch (e) {
-          logger.log(e)
-        }
-      })
-
-      // @ts-expect-error TODO: use @nuxt/bridge-schema
-      nuxt.hook('generate:page', async (result) => {
-        if (!result.html || result.error) return
-        result.html = await beasties.process(result.html)
-      })
+    const { allowRules, exact, nonce, ...runtimeOptions } = (options.config || {}) as CrittersConfig & ProcessorOptions
+    if (nonce) {
+      logger.warn('`critters.config.nonce` is not supported - the nonce is read from the request.')
     }
+
+    nuxt.options.nitro.virtual ||= {}
+    nuxt.options.nitro.virtual['#critters'] = () => {
+      const buildAssetsDir = withoutLeadingSlash(nuxt.options.app.buildAssetsDir)
+      // `url()` references are rebased against this href, so it has to be
+      // document-absolute or they resolve relative to the rendered route
+      const base = withLeadingSlash(nuxt.options.app.baseURL)
+      const plans: unknown[] = []
+      let cssSize = 0
+
+      for (const [fileName, css] of stylesheets) {
+        const href = joinURL(base, fileName.startsWith(buildAssetsDir) ? fileName : joinURL(buildAssetsDir, fileName))
+        const sheet = compileSheet(css, { href, allowRules, exact })
+        for (const warning of sheet.warnings) {
+          logger.warn(warning)
+        }
+        cssSize += sheet.size
+        plans.push(encodePlan(sheet))
+      }
+
+      const serialized = JSON.stringify(plans)
+      if (serialized.length > PLAN_SIZE_WARNING) {
+        logger.warn(`Compiled critical CSS plans add ${Math.round(serialized.length / 1024)}kB to the server bundle.`)
+      }
+
+      const cache = runtimeOptions.cache ?? cssSize >= CACHE_CSS_SIZE_THRESHOLD
+
+      return [
+        `export const plans = ${serialized}`,
+        `export const options = ${JSON.stringify({ ...runtimeOptions, cache })}`,
+      ].join('\n')
+    }
+
+    nuxt.options.nitro.externals ||= {}
+    nuxt.options.nitro.externals.inline ||= []
+    nuxt.options.nitro.externals.inline.push('beasties/runtime')
+
+    addServerPlugin(resolver.resolve('./runtime/nitro-plugin'))
   },
 })

--- a/src/runtime/critters.d.ts
+++ b/src/runtime/critters.d.ts
@@ -1,0 +1,6 @@
+declare module '#critters' {
+  import type { CompactPlan, ProcessorOptions } from 'beasties/runtime'
+
+  export const plans: CompactPlan[]
+  export const options: ProcessorOptions
+}

--- a/src/runtime/nitro-plugin.ts
+++ b/src/runtime/nitro-plugin.ts
@@ -1,0 +1,37 @@
+import { createProcessor } from 'beasties/runtime'
+import { defineNitroPlugin } from 'nitropack/runtime'
+import { options, plans } from '#critters'
+
+/**
+ * The shape of the `render:response` context we rely on, kept structural so the
+ * module does not depend on whichever module supplies the nonce.
+ */
+interface RenderContextLike {
+  event?: {
+    context?: {
+      security?: {
+        nonce?: string
+      }
+    }
+  }
+}
+
+export default defineNitroPlugin((nitroApp) => {
+  if (plans.length === 0) return
+
+  const processor = createProcessor(plans, options)
+
+  nitroApp.hooks.hook('render:response', (response, context) => {
+    if (typeof response.body !== 'string') return
+    const contentType = response.headers?.['content-type']
+    if (contentType && !contentType.includes('text/html')) return
+
+    try {
+      const nonce = (context as RenderContextLike).event?.context?.security?.nonce
+      response.body = processor.process(response.body, { nonce })
+    }
+    catch (error) {
+      console.error('[critters] Could not inline critical CSS.', error)
+    }
+  })
+})

--- a/test/fixtures/critters.ts
+++ b/test/fixtures/critters.ts
@@ -1,0 +1,8 @@
+import { compileSheet, encodePlan } from 'beasties/compiler'
+import type { CompactPlan, ProcessorOptions } from 'beasties/runtime'
+
+const css = `.used { color: red } .unused { color: blue }`
+
+export const plans: CompactPlan[] = [encodePlan(compileSheet(css, { href: '_nuxt/entry.css' }))]
+
+export const options: ProcessorOptions = { preload: 'media-script' }

--- a/test/fixtures/nitropack-runtime.ts
+++ b/test/fixtures/nitropack-runtime.ts
@@ -1,0 +1,3 @@
+export function defineNitroPlugin<T>(plugin: T): T {
+  return plugin
+}

--- a/test/generate.spec.ts
+++ b/test/generate.spec.ts
@@ -20,4 +20,27 @@ describe('module in generated pages', () => {
     expect(body).toContain('.sample-class')
     expect(body).not.toContain('.sample-unused-class')
   })
+
+  it('inlines used media queries and keyframes only', async () => {
+    const ctx = useTestContext()
+    const body = await fsp.readFile(
+      resolve(ctx.nuxt!.options.nitro.output?.dir || '', 'public/index.html'),
+      'utf-8',
+    )
+    const critical = body.match(/<style>(.*?)<\/style>/s)?.[1] || ''
+    expect(critical).toContain('.sample-media-class')
+    expect(critical).not.toContain('.sample-unused-media-class')
+    expect(critical).toContain('@keyframes sample-fade')
+    expect(critical).not.toContain('sample-unused-keyframes')
+  })
+
+  it('leaves the original stylesheets loading asynchronously', async () => {
+    const ctx = useTestContext()
+    const body = await fsp.readFile(
+      resolve(ctx.nuxt!.options.nitro.output?.dir || '', 'public/index.html'),
+      'utf-8',
+    )
+    expect(body).toContain('media="print"')
+    expect(body).toContain('<noscript>')
+  })
 })

--- a/test/nonce.spec.ts
+++ b/test/nonce.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import plugin from '../src/runtime/nitro-plugin'
+
+type NitroApp = Parameters<typeof plugin>[0]
+type RenderResponseHandler = Parameters<NitroApp['hooks']['hook']> extends [unknown, infer H] ? H : never
+
+const html = `<html><head><link rel="stylesheet" href="/_nuxt/entry.css"></head><body><div class="used"></div></body></html>`
+
+function createHandler() {
+  let handler: RenderResponseHandler | undefined
+  const nitroApp = {
+    hooks: {
+      hook(name: string, fn: RenderResponseHandler) {
+        if (name === 'render:response') {
+          handler = fn
+        }
+      },
+    },
+  } as unknown as NitroApp
+
+  plugin(nitroApp)
+
+  if (!handler) {
+    throw new Error('plugin did not register a `render:response` handler')
+  }
+
+  return handler
+}
+
+function render(nonce?: string) {
+  const response: { body?: string } = { body: html }
+  const handler = createHandler()
+  // @ts-expect-error the fake context only implements what the plugin reads
+  handler(response, { event: { context: nonce ? { security: { nonce } } : {} } })
+  return response.body!
+}
+
+describe('csp nonce', () => {
+  it('applies the per-request nonce to injected tags', () => {
+    const body = render('request-nonce')
+    expect(body).toContain('<style nonce="request-nonce">')
+    expect(body).toContain('<script nonce="request-nonce">')
+  })
+
+  it('injects no nonce when the request has none', () => {
+    expect(render()).not.toContain('nonce=')
+  })
+
+  it('does not let a cached render reuse a previous nonce', () => {
+    const handler = createHandler()
+    const first: { body?: string } = { body: html }
+    const second: { body?: string } = { body: html }
+    // @ts-expect-error the fake context only implements what the plugin reads
+    handler(first, { event: { context: { security: { nonce: 'first' } } } })
+    // @ts-expect-error the fake context only implements what the plugin reads
+    handler(second, { event: { context: { security: { nonce: 'second' } } } })
+    expect(first.body).toContain('nonce="first"')
+    expect(second.body).toContain('nonce="second"')
+    expect(second.body).not.toContain('nonce="first"')
+  })
+})

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url'
-import { setup, $fetch, useTestContext } from '@nuxt/test-utils'
+import { setup, $fetch } from '@nuxt/test-utils'
 import { describe, it, expect } from 'vitest'
 
 await setup({
@@ -7,14 +7,9 @@ await setup({
   server: true,
 })
 
-describe.skip('module in server', () => {
-  it('enables extractCSS', () => {
-    const ctx = useTestContext()
-    expect(ctx.nuxt!.options.build.extractCSS).toBeTruthy()
-  })
-
+describe('module in server', () => {
   it('inlines CSS', async () => {
-    const body = await $fetch('/')
+    const body = await $fetch<string>('/')
     expect(body).toContain('<style>')
     expect(body).toContain('.sample-class')
     expect(body).not.toContain('.sample-unused-class')

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    alias: {
+      '#critters': new URL('./test/fixtures/critters.ts', import.meta.url).pathname,
+      'nitropack/runtime': new URL('./test/fixtures/nitropack-runtime.ts', import.meta.url).pathname,
+    },
     coverage: {
       include: ['src'],
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt-modules/critters/issues/550
resolves https://github.com/nuxt-modules/critters/issues/21
resolves https://github.com/nuxt-modules/critters/issues/7
resolves https://github.com/nuxt-modules/critters/issues/1

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

until now this module only really worked properly for prerendering. the runtime implementation ran classic `beasties` over the rendered HTML on every request - which was extremely wasteful: it meant parsing the stylesheets with postcss, building a DOM with `htmlparser2`, running `css-select` over it, and then serialising back

`beasties@0.5` now splits that into two halves (https://github.com/danielroe/beasties/pull/403), so this rewires the module to use them:

- at build time we walk the CSS assets the client build emits, compile to a compact 'plan' and then embed the plans in the server bundle
- at request time a nitro plugin hooks `render:response` and processes these plans based on the body, scanning the markup in a single pass with _no CSS parser and no DOM_

> [!IMPORTANT]
> rather than have two implementations, we use this compiler + runtime approach for both runtime SSR and prerendering...

the module also now sets `features.inlineStyles: false`, to avoid duplication between inline styles and css stylesheets. in future I am considering making this a built-in alternative to the existing nuxt inlineStyles implemenation (https://github.com/nuxt/nuxt/issues/35250).

we cache results based on your total compiled CSS size, though you can override this with `cache: true` or `cache: false`

### 💥 Breaking

some classic options have no equivalent in a compiler + runtime split:

| option | why |
| --- | --- |
| `pruneSource` | the runtime doesn't rewrite the external stylesheet, so inlined rules are still served by it |
| `path`, `publicPath`, `external`, `remote`, `additionalStylesheets`, `mergeStylesheets` | only stylesheets emitted as part of the build are currently supported |
| `reduceInlineStyles`, `compress`, `safeParser`, `logLevel`, `logger`, `dedupeWarnings` | parsing, minification and diagnostics are all build-time now; compiler warnings go through the nuxt logger |

`minimumExternalSize` also changes meaning slightly: it's measured against the rules that were _not_ inlined, i.e. what the external stylesheet would still need to provide, rather than against a rewritten stylesheet.

### 🔐 CSP nonces

we now support reading a per-request value from `event.context.security.nonce` and stamping it on the `<style>` and `<script>` elements it injects, so `nuxt-security` with `nonce` enabled needs no configuration here.

when https://github.com/nuxt/nuxt/issues/11793 lands, we'll support that too...